### PR TITLE
Dev etparser

### DIFF
--- a/benchmark/linalg_libs/gflops.py
+++ b/benchmark/linalg_libs/gflops.py
@@ -1,8 +1,16 @@
+from typing import Callable
+
 from tabulate import tabulate
 from timeit import timeit
 import numpy as np
 import torch as pt
 import tensorflow as tf
+
+from numpy.typing import ArrayLike
+from tensorflow import Tensor as TFTensor
+from torch import Tensor as PTTensor
+
+Array = ArrayLike | PTTensor | TFTensor
 
 
 def get_gflops(ops: float, seconds: float) -> float:
@@ -17,32 +25,41 @@ def make_table(t_values: dict) -> None:
           "secs", "relative throughput", "Size")))
 
 
+def measure_expr(A: Array,
+                 B: Array,
+                 sin: Callable[[Array], Array],
+                 cos: Callable[[Array], Array],
+                 matmul: Callable[[Array, Array], Array],
+                 t_number: int = 3) -> float:
+    return timeit(lambda: 2 + matmul(A, B) + A * B * matmul(sin(A), cos(A) + B) + 3., number=t_number)/t_number
+
+
 if __name__ == "__main__":
     table = []
-    M, N, K = 8192, 8192, 8192
-    nsec: int = 102409764 * 1e-9  # 49758236*1e-9  # 38_283_092_347
+    M, N, K = 256, 256, 256
+    nsec: int = 230162833 * 1e-9  # 49758236*1e-9  # 38_283_092_347
 
-    floating_ops: int = 2 * M*N*K  # 4*M*N*K + 5*M*N
+    floating_ops: int = 4*M*N*K + 5*M*N  # 2 * M*N*K
     lm_gflops: int = get_gflops(floating_ops, nsec)
     table.append(("lazy_mat", lm_gflops, nsec, '---', f'{M}x{N}x{K}'))
 
     np_A = np.random.rand(M, N)
     np_B = np.random.rand(M, K)
-    np_sec = timeit(lambda: np_A@np_B, number=3)/3
+    np_sec = measure_expr(np_A, np_B, np.sin, np.cos, np.matmul)
     np_gflops = get_gflops(floating_ops, np_sec)
     table.append(("numpy", np_gflops,
                  np_sec, f'{lm_gflops/np_gflops: .4f}x', f'{M}x{N}x{K}'))
 
     pt_A = pt.tensor(np_A)
     pt_B = pt.tensor(np_B)
-    pt_sec = timeit(lambda: pt.matmul(pt_A, pt_B), number=3)/3
+    pt_sec = measure_expr(pt_A, pt_B, pt.sin, pt.cos, pt.matmul)
     pt_gflops = get_gflops(floating_ops, pt_sec)
     table.append(("pytorch", pt_gflops, pt_sec,
                  f'{lm_gflops/pt_gflops: .4f}x', f'{M}x{N}x{K}'))
 
     tf_A = tf.convert_to_tensor(np_A)
     tf_B = tf.convert_to_tensor(np_B)
-    tf_sec = timeit(lambda: tf.matmul(tf_A, tf_B), number=3)/3
+    tf_sec = measure_expr(tf_A, tf_B, tf.sin, tf.cos, tf.matmul)
     tf_gflops = get_gflops(floating_ops, tf_sec)
     table.append(("tensorflow", tf_gflops, tf_sec,
                  f'{lm_gflops/tf_gflops: .4f}x', f'{M}x{N}x{K}'))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,20 +11,20 @@ auto main() -> int {
   std::mt19937 rng_a(67);
   std::mt19937 rng_b(65);
 
-  constexpr int M = 256;
-  constexpr int N = 256;
-  constexpr int K = 256;
+  constexpr int M = 16;
+  constexpr int N = 17;
+  constexpr int K = 18;
 
   Matrix<float, M, N> A{make_vmatrix<float, M, N>(std::ref(rng_a))};
-  Matrix<float, M, K> B{make_vmatrix<float, M, K>(std::ref(rng_b))};
+  Matrix<float, N, K> B{make_vmatrix<float, N, K>(std::ref(rng_b))};
 
-  Matrix<float, K, N> C;
+  // Matrix<float, K, N> C;
   {
     const std::size_t iterations = 3;
     Timer t{iterations};
     t.start();
     for (std::size_t i = 0; i < iterations; i++) {
-      C = 2 + matmul(A, B) + A * B * matmul(sin(A), cos(A) + B) + 3.;
+      auto C = 2 + matmul(A, B) + A * B * matmul(sin(A), cos(A) + B) + 3.;
     }
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,14 +6,16 @@
 
 using namespace lm;
 
-auto main() -> int {
+auto main(int argc, char **argv) -> int {
 
   std::mt19937 rng_a(67);
   std::mt19937 rng_b(65);
 
-  constexpr int M = 10;
-  constexpr int N = 10;
-  constexpr int K = 10;
+  // get the matrix dimensions from command line
+
+  constexpr int M = 4096 * 2;
+  constexpr int N = 4096 * 2;
+  constexpr int K = 4096 * 2;
 
   Matrix<float, M, N> A{make_vmatrix<float, M, N>(std::ref(rng_a))};
   Matrix<float, N, K> B{make_vmatrix<float, N, K>(std::ref(rng_b))};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,9 +11,9 @@ auto main() -> int {
   std::mt19937 rng_a(67);
   std::mt19937 rng_b(65);
 
-  constexpr int M = 16;
-  constexpr int N = 17;
-  constexpr int K = 18;
+  constexpr int M = 10;
+  constexpr int N = 10;
+  constexpr int K = 10;
 
   Matrix<float, M, N> A{make_vmatrix<float, M, N>(std::ref(rng_a))};
   Matrix<float, N, K> B{make_vmatrix<float, N, K>(std::ref(rng_b))};

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -318,6 +318,21 @@ TEST(TestElementWiseOps, DeathAssertion) {
   EXPECT_DEATH({ M0 % M1; }, "Dimensions mismatch");
 }
 #endif
+
+TEST(MatExpr, Integration) {
+  const Matrix<int, 3, 3> M0{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+  const Matrix<int, 3, 4> M1{{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}};
+
+  const Matrix<int, 3, 4> M3{
+      {1, 4, 9, 16}, {25, 36, 49, 64}, {81, 100, 121, 144}};
+
+  const Matrix<int, 3, 4> MatmulM0M1{
+      {38, 44, 50, 56}, {83, 98, 113, 128}, {128, 152, 176, 200}};
+
+  // const auto result = 1 + matmul(M0, M1) * M3 + 3;
+  const auto dumb = matmul(M0, M1);
+  // EXPECT_EQ(dumb, MatmulM0M1);
+}
 // TEST(Parser, UnaryParser) {}
 
 // TEST(Parser, BinaryParser) {

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -8,10 +8,6 @@
 #include <cmath>
 #include <random>
 
-#ifdef DEBUG
-#include <stdexcept>
-#endif
-
 using namespace lm;
 
 TEST(BinaryExpr, EqualityOps) {
@@ -297,12 +293,29 @@ TEST(TestMatMulExpr, ThrowException) {
   std::mt19937 rng_a(64);
   std::mt19937 rng_b(65);
 
-  // try {
-  //   matmul(Matrix<int, M, 6>{make_vmatrix<int, M, 6>(std::ref(rng_a))},
-  //          Matrix<int, N, K>{make_vmatrix<int, N, K>(std::ref(rng_b))});
-  // } catch (const std::runtime_error &e) {
-  //   EXPECT_STREQ(e.what(), "Dimensions mismatch");
-  // }
+  EXPECT_DEATH(
+      {
+        matmul(Matrix<int, M, 6>{make_vmatrix<int, M, 6>(std::ref(rng_a))},
+               Matrix<int, N, K>{make_vmatrix<int, N, K>(std::ref(rng_b))});
+      },
+      "Dimensions mismatch");
+}
+
+TEST(TestElementWiseOps, DeathAssertion) {
+  const std::size_t M = 3;
+  const std::size_t N = 4;
+
+  std::mt19937 rng_a(64);
+  std::mt19937 rng_b(65);
+
+  const Matrix<int, M, N> M0{make_vmatrix<int, M, N>(std::ref(rng_a))};
+  const Matrix<int, N, N> M1{make_vmatrix<int, N, N>(std::ref(rng_b))};
+
+  EXPECT_DEATH({ M0 + M1; }, "Dimensions mismatch");
+  EXPECT_DEATH({ M0 - M1; }, "Dimensions mismatch");
+  EXPECT_DEATH({ M0 *M1; }, "Dimensions mismatch");
+  EXPECT_DEATH({ M0 / M1; }, "Dimensions mismatch");
+  EXPECT_DEATH({ M0 % M1; }, "Dimensions mismatch");
 }
 #endif
 // TEST(Parser, UnaryParser) {}

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -320,18 +320,33 @@ TEST(TestElementWiseOps, DeathAssertion) {
 #endif
 
 TEST(MatExpr, Integration) {
-  const Matrix<int, 3, 3> M0{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
-  const Matrix<int, 3, 4> M1{{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}};
+  const std::size_t M = 3;
+  const std::size_t N = 3;
+  const std::size_t K = 3;
 
-  const Matrix<int, 3, 4> M3{
-      {1, 4, 9, 16}, {25, 36, 49, 64}, {81, 100, 121, 144}};
+  std::mt19937 rng_a(64);
+  std::mt19937 rng_b(65);
 
-  const Matrix<int, 3, 4> MatmulM0M1{
-      {38, 44, 50, 56}, {83, 98, 113, 128}, {128, 152, 176, 200}};
+  const Matrix<double, M, N> M0{make_vmatrix<double, M, N>(std::ref(rng_a))};
+  const Matrix<double, N, K> M1{make_vmatrix<double, N, K>(std::ref(rng_b))};
 
-  // const auto result = 1 + matmul(M0, M1) * M3 + 3;
-  const auto dumb = matmul(M0, M1);
-  // EXPECT_EQ(dumb, MatmulM0M1);
+  const Matrix<double, M, K> M3{make_vmatrix<double, M, K>(std::ref(rng_a))};
+  const Matrix<double, M, K> M4{make_vmatrix<double, M, K>(std::ref(rng_b))};
+
+  const auto Result =
+      1 + matmul(M0, sin(M1)) + matmul(cos(M0), sin(M1)) + M3 * M4 + 4.;
+
+  for (std::size_t i = 0; i < M; i++) {
+    for (std::size_t j = 0; j < K; j++) {
+      double sum1 = 0;
+      double sum2 = 0;
+      for (std::size_t k = 0; k < N; k++) {
+        sum1 += M0(i, k) * std::sin(M1(k, j));
+        sum2 += std::cos(M0(i, k)) * std::sin(M1(k, j));
+      }
+      EXPECT_DOUBLE_EQ(Result(i, j), 1 + sum1 + sum2 + M3(i, j) * M4(i, j) + 4);
+    }
+  }
 }
 // TEST(Parser, UnaryParser) {}
 


### PR DESCRIPTION
Update
- Added debug mode for testing matrix sizes in `MatMulExpr` on a specialized template
- Removed overload to `operator==` for matmul size assertions
- Added assertions for `BinaryExpr` for equal sizes
- Added DEATH assertions to test when the constructor successfully fails 
- Refactored `gflops.py` bench for modularity of measuring expr